### PR TITLE
GoPlus - TokensList.org-Style Attestation List

### DIFF
--- a/contributions/token-list-style-attestation-list.md
+++ b/contributions/token-list-style-attestation-list.md
@@ -3,15 +3,15 @@ title: "TokensList.org-Style Attestation List"
 description: "The TokensList allows users to publish and discover lists of tokens maintained by teams and projects. These lists of tokens make it possible for teams to signal the legitimacy of certain tokens and help users filter out spam. We need this same kind of infra for the Attestation Station. "
 lang: "en-US"
 type: "Draft Project Idea"
-authors: ["@smartcontracts (GitHub) @ OP Labs"]
+authors: [@0xelpeze (Twitter) @ GoPlusSecurity" ,  "@theyavuzaslan (Twitter) @ GoPlusSecurity" ]
 category: "dev-tooling"
 effort: "Large"
 skill-sets: ["Front End Development", "Back End Development", "Full Stack Development", "Smart Contract Development"]
 labels: [ "Attestations", "Developer Tooling", "Chain Infrastructure", "Accessibility/Transparency"]
 contributions:
-  contributors: [""]
-  discussion-link: ""
-  links: [""]
+  contributors: ["@0xelpeze (Twitter) @ GoPlusSecurity" , "@theyavuzaslan (Twitter) @ GoPlusSecurity" , "@Allen @GoPlusSecurity"]
+  discussion-link: "https://github.com/ethereum-optimism/ecosystem-contributions/discussions/186"
+  links: ["gopluslabs.io"]
   execution-status: "not-started"
 ---
 


### PR DESCRIPTION
Hi from Goplus team,
As GoPlus, we offer security solutions for users in the crypto market. Therefore, since we work on the security of tokens, we are very experienced in the field of token classification.

We are ready to use our experience for [TokensList.org-Style Attestation List](https://contribute.optimism.io/issue/token-list-style-attestation-list).

The TokensList allows users to publish and discover lists of tokens maintained by teams and projects. These lists of tokens make it possible for teams to signal the legitimacy of certain tokens and help users filter out spam. We need this same kind of infra for the Attestation Station.

 Possible Features
-An instance of an attestation list following a standard JSON schema and can -be hosted publicly on ENS, IPFS, or HTTPS.
-Context on what attestation lists are
-Directions on how to validate that a schemas follow the proposed standard
-Directions on how to author a attestation list
         List data
                 List URL
                 List Name
                  List version
                  Link to the official homepage of the list manager
        Attestation data
               Attestation name
               Attestation author
               Attestation key
               Attestation value
               Attestation image
               Attestation description
-Directions on how to deploy an attestation list
-Examples of what a attestation list looks like
